### PR TITLE
Add default case for switch statements

### DIFF
--- a/src/main/java/org/wipf/jasmarty/logic/jasmarty/PageConverter.java
+++ b/src/main/java/org/wipf/jasmarty/logic/jasmarty/PageConverter.java
@@ -336,6 +336,12 @@ public class PageConverter {
 			case 3:
 				sb.append(BLOCK_3_3);
 				break;
+					
+			//missing default case
+        		default:
+            		    // add default case
+            			break;
+
 			}
 
 			// Leere Blöcke:


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html