### PR TITLE
Add default case for switch statements

### DIFF
--- a/src/main/java/org/wipf/jasmarty/logic/jasmarty/extensions/Winamp.java
+++ b/src/main/java/org/wipf/jasmarty/logic/jasmarty/extensions/Winamp.java
@@ -55,6 +55,11 @@ public class Winamp {
 		case "start":
 			WinampController.run();
 			break;
+		//missing default case
+        	default:
+            	// add default case
+            		break;
+
 		}
 	}
 


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html