### PR TITLE
Add default case for switch statements

### DIFF
--- a/src/main/java/org/wipf/jasmarty/datatypes/LcdCache.java
+++ b/src/main/java/org/wipf/jasmarty/datatypes/LcdCache.java
@@ -172,6 +172,10 @@ public class LcdCache {
 				case 0x09:
 					c = '?';
 					break;
+				//missing default case
+        			default:
+       				     // add default case
+            				break;
 				}
 				sb.append(c);
 			}


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html